### PR TITLE
 Core/Creatures: Don't remove hovering from creatures that can fly #28217

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2792,7 +2792,7 @@ void Creature::UpdateMovementFlags()
         else
             SetDisableGravity(true);
 
-        if (!HasAuraType(SPELL_AURA_HOVER))
+        if (!HasAuraType(SPELL_AURA_HOVER) && GetMovementTemplate().Ground != CreatureGroundMovementType::Hover)
             SetHover(false);
     }
     else


### PR DESCRIPTION
[Core/Creatures: Don't remove hovering from creatures that can fly](https://github.com/TrinityCore/TrinityCore/pull/28217) #28217