### PR TITLE
Core/Player: Distinguish between ranged and non-ranged weapons in GetWeaponForAttack

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -10235,7 +10235,11 @@ Item* Player::GetWeaponForAttack(WeaponAttackType attackType, bool useable /*= f
         item = GetUseableItemByPos(INVENTORY_SLOT_BAG_0, slot);
     else
         item = GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
+
     if (!item || item->GetTemplate()->GetClass() != ITEM_CLASS_WEAPON)
+        return nullptr;
+
+    if ((attackType == RANGED_ATTACK) != item->GetTemplate()->IsRangedWeapon())
         return nullptr;
 
     if (!useable)


### PR DESCRIPTION
[Core/Player: Distinguish between ranged and non-ranged weapons in GetWeaponForAttack…](https://github.com/TCDEVEmu/TCDEVEmu/commit/b249f559270ad0ee26c9aa477cde409604561fc2) 

